### PR TITLE
Allow non-DC metadata fields

### DIFF
--- a/src/edu/osu/kb/batch/OutputXML.java
+++ b/src/edu/osu/kb/batch/OutputXML.java
@@ -10,8 +10,9 @@ public class OutputXML
     private FileOutputStream FOS;
     private OutputStreamWriter OSW;
     private BufferedWriter BW;
+	private String schema;
 
-    public OutputXML(String outputFile)
+	public OutputXML(String outputFile)
     {
         //File should not already exist
         //TODO DELETE THIS
@@ -34,11 +35,19 @@ public class OutputXML
         }
     }
 
-    public void start()
+	public OutputXML(String outputFile, String schema) {
+		this(outputFile);
+		this.schema = schema;
+	}
+
+	public void start()
     {
         try {
             writer.writeXmlVersion("1.0", "UTF-8");
             writer.writeEntity("dublin_core");
+	        if (schema != null && !"dc".contentEquals(schema)) {
+		        writer.writeAttribute("schema", schema);
+	        }
         } catch (Exception e) {
             if (e.getMessage() != null) {
                 System.out.println(e.getMessage());


### PR DESCRIPTION
The SimpleArchiveFormat accepts metadata for non-Dublin Core fields. The requirements are:

> It is possible to use other Schema such as EAD, VRA Core, etc. Make sure you
> have defined the new scheme in the DSpace Metada Schema Registry.
> 1. Create a separate file for the other schema named metadata_[prefix].xml,
>    where the [prefix] is replaced with the schema's prefix.
> 2. Inside the xml file use the dame Dublin Core syntax, but on the
>    <dublin_core> element include the attribute schema=[prefix].

(https://wiki.duraspace.org/display/DSDOC18/Importing+and+Exporting+Items+via+Simple+Archive+Format#ImportingandExportingItemsviaSimpleArchiveFormat-Configuringmetadata_[prefix].xmlforDifferentSchema)

This commit contains the changes necessary to make SAFBuilder create these
additional XML files in the format required.
