### PR TITLE
Produce an executable JAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 out/
 *.class
 target
+dependency-reduced-pom.xml
 
 #Local stash for .jars
 lib-files/

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,6 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
-        </dependency>
-        <dependency>
             <groupId>commons-vfs</groupId>
             <artifactId>commons-vfs</artifactId>
             <version>1.0</version>
@@ -79,6 +74,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,25 @@
                     <target>1.6</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>safbuilder.BatchProcess</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
These changes cause `mvn package` to build a JAR that contains all dependencies and sufficient information in the manifest that it can be run using something like `java -jar safbuilder.jar --this --that`.  The JAR should be portable to any system that has a JRE installed -- it does **not** require Maven, as the scripts do.  (I have **not** checked the dependencies' licenses to see whether the JAR can be _distributed_ to other sites.  You will want to do your own evaluation anyway.)
