### PR TITLE
fix safbuilder.sh

### DIFF
--- a/safbuilder.sh
+++ b/safbuilder.sh
@@ -4,6 +4,19 @@ mvn --quiet -DskipTests=true clean package
 
 ## arg1 = Path to content files directory
 ## arg2 = Metadata CSV filename
-args="$1 $2 $3 $4 $5 $6"
-argsTrim=$(echo $args | sed 's/ *$//')
-mvn --quiet exec:java -Dexec.mainClass="safbuilder.BatchProcess" -Dexec.args="$argsTrim"
+# args="$1 $2 $3 $4 $5 $6"
+# argsTrim=$(echo $args | sed 's/ *$//')
+args=("$1" "$2" "$3" "$4" "$5" "$6")
+argsOut=""
+
+for i in ${!args[*]}; do
+  arg="${args[$i]}"
+  if [ "$arg" != "" ]; then
+    if [ "${arg:0:1}" != "-" ]; then
+      arg="'$arg'"
+    fi
+    argsOut="$argsOut $arg"
+  fi
+done
+
+mvn --quiet exec:java -Dexec.mainClass="safbuilder.BatchProcess" -Dexec.args="$argsOut"


### PR DESCRIPTION
The current `safbuilder.sh` doesn't allow spaces in the CSV filename, even when wrapped in quotes.

This fix wraps all non-flag args in single quotes, which may not be the ideal solution, but should be fine for most use cases.