### PR TITLE
fix globalFileParameters

### DIFF
--- a/src/main/java/safbuilder/SAFPackage.java
+++ b/src/main/java/safbuilder/SAFPackage.java
@@ -289,7 +289,7 @@ public class SAFPackage {
                 if (Arrays.asList(filenameColumn).contains(getHeaderField(j))) {
                     // filename
                     processMetaBodyRowFile(contentsWriter, currentItemDirectory, currentLine[j], "");
-                } else if (Arrays.asList(filenameWithPartsColumn).contains(getHeaderField(j))) {
+                } else if (StringUtils.indexOfAny(getHeaderField(j), filenameWithPartsColumn) >= 0 ) {
                     // filename__
                     //This file has extra parameters, such as being destined for a bundle, or specifying primary
                     String[] filenameParts = getHeaderField(j).split("__", 2);


### PR DESCRIPTION
The current SAFPackage doesn't actually let you specify `globalFileParameters` as part of a column header, e.g.: `filename__primary:true`. [Line 292](https://github.com/DSpace-Labs/SAFBuilder/blob/master/src/main/java/safbuilder/SAFPackage.java#L292) will only match `filename__`, not `filename__primary:true`.