### PR TITLE
add '-o' option for renaming output folder

### DIFF
--- a/src/main/java/safbuilder/BatchProcess.java
+++ b/src/main/java/safbuilder/BatchProcess.java
@@ -14,6 +14,7 @@ public class BatchProcess {
         options.addOption("m", "manifest", false, "Initialize a spreadsheet, a manifest listing all of the files in the directory, you must specify a CSV for -c ");
         options.addOption("s", "symbolicLink", false, "Set a Symbolic Link for bitstreams (instead of copying them)");
         options.addOption("z", "zip", false, "(optional) ZIP the output");
+        options.addOption("o", "output-name", true, "(optional) Name the output file");
 
         CommandLine commandLine = parser.parse(options, args);
 
@@ -23,7 +24,8 @@ public class BatchProcess {
             System.exit(0);
         }
 
-        SAFPackage safPackageInstance = new SAFPackage();
+        String outputName = commandLine.hasOption('o')? commandLine.getOptionValue('o') : "SimpleArchiveFormat";
+        SAFPackage safPackageInstance = new SAFPackage(outputName);
 
         if(commandLine.hasOption('m') && commandLine.hasOption('c')) {
             safPackageInstance.generateManifest(commandLine.getOptionValue('c'));

--- a/src/main/java/safbuilder/SAFPackage.java
+++ b/src/main/java/safbuilder/SAFPackage.java
@@ -30,7 +30,7 @@ public class SAFPackage {
     // Storage of the csv data.
     private CsvReader inputCSV;
 
-    private final String simpleArchiveFormat = "SimpleArchiveFormat";
+    private String output_filename;
     
     //Set a a Symbolic Link for filesinstead of copying them
     private boolean symbolicLink = false;
@@ -39,7 +39,8 @@ public class SAFPackage {
      * Default constructor. Main method of this class is processMetaPack. The goal of this is to create a Simple Archive Format
      * package from input of files and csv metadata.
      */
-    public SAFPackage() {
+    public SAFPackage(String outputFilename) {
+        this.output_filename = outputFilename;
     }
 
     
@@ -138,8 +139,8 @@ public class SAFPackage {
     }
 
     public void exportToZip(String pathToDirectory) {
-        String safDirectory = pathToDirectory + "/" + simpleArchiveFormat;
-        String zipDest = pathToDirectory + "/" + simpleArchiveFormat + ".zip";
+        String safDirectory = pathToDirectory + "/" + output_filename;
+        String zipDest = pathToDirectory + "/" + output_filename + ".zip";
         try {
             ZipUtil.createZip(safDirectory, zipDest);
             System.out.println("ZIP file located at: " + new File(zipDest).getAbsolutePath());
@@ -153,7 +154,7 @@ public class SAFPackage {
      */
     private void prepareSimpleArchiveFormatDir() {
 
-        File newDirectory = new File(input.getPath() + "/" + simpleArchiveFormat);
+        File newDirectory = new File(input.getPath() + "/" + output_filename);
         if (newDirectory.exists()) {
             try {
                 FileUtils.deleteDirectory(newDirectory);
@@ -442,7 +443,7 @@ public class SAFPackage {
      * @return Absolute path to the newly created directory
      */
     private String makeNewDirectory(int itemNumber) {
-        File newDirectory = new File(input.getPath() + "/" + simpleArchiveFormat + "/item_" + itemNumber);
+        File newDirectory = new File(input.getPath() + "/" + output_filename + "/item_" + itemNumber);
         newDirectory.mkdir();
         return newDirectory.getAbsolutePath();
     }


### PR DESCRIPTION
minimal changes to add new '-o' flag.

changes made:
- added new `commandOption` to `BatchProcess.java`
- updated SAFBuilder constructor to take in a String for the filename
- renamed and updated references to former filename string.

_note: it may be worthwhile to write a function to _sanitize_ the string name from the input (remove appropriate symbols) to guard against unexpected behavior and _path traversal_. i kept this out for simplicity, and, because it is a self-service, locally run application there is little security concern. I'd be happy to add it upon request, though._