### PR TITLE
Code cleanup to specifying output directory and add tests

### DIFF
--- a/src/main/java/safbuilder/BatchProcess.java
+++ b/src/main/java/safbuilder/BatchProcess.java
@@ -24,8 +24,12 @@ public class BatchProcess {
             System.exit(0);
         }
 
-        String outputName = commandLine.hasOption('o')? commandLine.getOptionValue('o') : "SimpleArchiveFormat";
-        SAFPackage safPackageInstance = new SAFPackage(outputName);
+        SAFPackage safPackageInstance;
+        if(commandLine.hasOption('o')) {
+            safPackageInstance = new SAFPackage(commandLine.getOptionValue('o'));
+        } else {
+            safPackageInstance = new SAFPackage();
+        }
 
         if(commandLine.hasOption('m') && commandLine.hasOption('c')) {
             safPackageInstance.generateManifest(commandLine.getOptionValue('c'));

--- a/src/main/java/safbuilder/SAFPackage.java
+++ b/src/main/java/safbuilder/SAFPackage.java
@@ -12,16 +12,14 @@ import org.mozilla.universalchardet.UniversalDetector;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPut;
 
 import java.io.*;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 
-public class SAFPackage {
+class SAFPackage {
     private String seperatorRegex = "\\|\\|";   // Using double pipe || to separate multiple values in a field.
 
     // Directory on file system of this input collection
@@ -30,21 +28,27 @@ public class SAFPackage {
     // Storage of the csv data.
     private CsvReader inputCSV;
 
-    private String output_filename;
-    
-    //Set a a Symbolic Link for filesinstead of copying them
+    // Default outputFilename is "SimpleArchiveFormat", can be  overridden
+    private String outputFilename = "SimpleArchiveFormat";
+
+    //Set a a Symbolic Link for files instead of copying them
     private boolean symbolicLink = false;
 
     /**
      * Default constructor. Main method of this class is processMetaPack. The goal of this is to create a Simple Archive Format
      * package from input of files and csv metadata.
      */
-    public SAFPackage(String outputFilename) {
-        this.output_filename = outputFilename;
+    SAFPackage() {}
+
+    /**
+     * Constructor that allows you to set output directory
+     * @param outputFilename Custom directory name that SAF output goes to
+     */
+    SAFPackage(String outputFilename) {
+        this.outputFilename = outputFilename;
     }
 
-    
-    public void setSymbolicLink(boolean symbolicLink) {
+    void setSymbolicLink(boolean symbolicLink) {
         this.symbolicLink = symbolicLink;
     }
 
@@ -139,8 +143,8 @@ public class SAFPackage {
     }
 
     public void exportToZip(String pathToDirectory) {
-        String safDirectory = pathToDirectory + "/" + output_filename;
-        String zipDest = pathToDirectory + "/" + output_filename + ".zip";
+        String safDirectory = pathToDirectory + "/" + outputFilename;
+        String zipDest = pathToDirectory + "/" + outputFilename + ".zip";
         try {
             ZipUtil.createZip(safDirectory, zipDest);
             System.out.println("ZIP file located at: " + new File(zipDest).getAbsolutePath());
@@ -154,7 +158,7 @@ public class SAFPackage {
      */
     private void prepareSimpleArchiveFormatDir() {
 
-        File newDirectory = new File(input.getPath() + "/" + output_filename);
+        File newDirectory = new File(input.getPath() + "/" + outputFilename);
         if (newDirectory.exists()) {
             try {
                 FileUtils.deleteDirectory(newDirectory);
@@ -376,7 +380,7 @@ public class SAFPackage {
              */
             String[] filenameParts = (files[j].trim() + "__").split("__", 2);
             String currentFile = filenameParts[0];
-            
+
             /* This takes the parameters as specified at the header row and adds them to the
              * parameters for this individual file. The order is important here: by taking
              * the local parameters first, they are able to override the global params.
@@ -384,11 +388,11 @@ public class SAFPackage {
             String fileParameters = filenameParts[1] + "__" + globalFileParameters;
 
             try {
-                
+
                 //copying files
                 if (!symbolicLink) {
                     FileUtils.copyFileToDirectory(new File(input.getPath() + "/" + currentFile), new File(itemDirectory));
-                } 
+                }
                 //instead of copying them, set a symbolicLink
                 else {
                     Path pathLink = (new File(input.getPath() + "/" + currentFile)).toPath();
@@ -443,7 +447,7 @@ public class SAFPackage {
      * @return Absolute path to the newly created directory
      */
     private String makeNewDirectory(int itemNumber) {
-        File newDirectory = new File(input.getPath() + "/" + output_filename + "/item_" + itemNumber);
+        File newDirectory = new File(input.getPath() + "/" + outputFilename + "/item_" + itemNumber);
         newDirectory.mkdir();
         return newDirectory.getAbsolutePath();
     }

--- a/src/test/java/safbuilder/SAFPackageTest.java
+++ b/src/test/java/safbuilder/SAFPackageTest.java
@@ -3,12 +3,17 @@ package safbuilder;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
+import org.apache.commons.io.FileUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Unit test for simple App.
  */
-public class SAFPackageTest
-        extends TestCase {
+public class SAFPackageTest extends TestCase {
     /**
      * Create the test case
      *
@@ -30,5 +35,31 @@ public class SAFPackageTest
      */
     public void testApp() {
         assertTrue(true);
+    }
+
+    public void testInitDefault() {
+        Path outputDirectory = Paths.get("src", "sample_data", "SimpleArchiveFormat");
+        SAFPackage safPackage = new SAFPackage();
+        generateSampleAndAssertCreated(safPackage, outputDirectory);
+    }
+
+    public void testInitWithOutputPath() {
+        String randomPath =  "__test_output__" + System.currentTimeMillis();
+        Path outputDirectory = Paths.get("src", "sample_data", randomPath);
+        SAFPackage safPackage = new SAFPackage(randomPath);
+        generateSampleAndAssertCreated(safPackage, outputDirectory);
+    }
+
+    private void generateSampleAndAssertCreated(SAFPackage safPackageInstance,  Path outputDirectory) {
+        String sampleCSV = Paths.get("src", "sample_data", "AAA_batch-metadata.csv").toAbsolutePath().toString();
+        try {
+            FileUtils.deleteDirectory(outputDirectory.toFile()); // ensure that it doesn't exist
+            safPackageInstance.processMetaPack(sampleCSV, false);
+            assert Files.exists(outputDirectory);
+            FileUtils.deleteDirectory(outputDirectory.toFile());
+        } catch (IOException e) {
+            System.out.println(e.getMessage());
+            assert false;
+        }
     }
 }


### PR DESCRIPTION
This does some small code-cleanup on-top of work by @atla5 in https://github.com/DSpace-Labs/SAFBuilder/pull/15

I've done some small refactoring, and added tests to assert that the custom output directory was created.

Tests can be  run with `mvn tests`.

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running safbuilder.SAFPackageTest
Detected input CSV as:UTF-8
Opened CSV File:/Users/pdietz/Workspaces/personal/SAFBuilder/src/sample_data/AAA_batch-metadata.csv
Output directory is: /Users/pdietz/Workspaces/personal/SAFBuilder/src/sample_data/SimpleArchiveFormat
File: AAA_batch-metadata-language.csv has been used 0 times.
File: AAA_batch-metadata_8859.csv has been used 0 times.
File: AAA_batch-metadata.csv has been used 0 times.
Detected input CSV as:UTF-8
Opened CSV File:/Users/pdietz/Workspaces/personal/SAFBuilder/src/sample_data/AAA_batch-metadata.csv
Output directory is: /Users/pdietz/Workspaces/personal/SAFBuilder/src/sample_data/__test_output__1552360758083
File: AAA_batch-metadata-language.csv has been used 0 times.
File: AAA_batch-metadata_8859.csv has been used 0 times.
File: AAA_batch-metadata.csv has been used 0 times.
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.372 sec

Results :

Tests run: 3, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.733 s
[INFO] Finished at: 2019-03-11T23:19:18-04:00
[INFO] ------------------------------------------------------------------------
```