### PR TITLE
Ensuring item import in order as defined in CSV

### DIFF
--- a/src/main/java/safbuilder/SAFPackage.java
+++ b/src/main/java/safbuilder/SAFPackage.java
@@ -34,6 +34,9 @@ class SAFPackage {
     //Set a a Symbolic Link for files instead of copying them
     private boolean symbolicLink = false;
 
+    // Formatstring for itemNumber used for creating the Zip - Entries based on number of CSV records
+    private String itemNumberFormatString = "%d";
+
     /**
      * Default constructor. Main method of this class is processMetaPack. The goal of this is to create a Simple Archive Format
      * package from input of files and csv metadata.
@@ -127,6 +130,8 @@ class SAFPackage {
 
         prepareSimpleArchiveFormatDir();
 
+        prepareItemNumberFormatString(pathToDirectory, metaFileName);
+
         processMetaHeader();
         processMetaBody();
 
@@ -135,6 +140,17 @@ class SAFPackage {
         }
 
         printFiles(0);                                                          // print a report of files not used
+    }
+
+    private void prepareItemNumberFormatString(String pathToDirectory, String metaFileName) throws IOException {
+        while (inputCSV.readRecord()) {
+            // loop needed to calculate number of data records
+        }
+        long numberOfDataRecords = inputCSV.getCurrentRecord();
+        if (numberOfDataRecords > 0) {
+            itemNumberFormatString = "%0" + String.valueOf(numberOfDataRecords).length() + "d";
+        }
+        openCSV(pathToDirectory, metaFileName);
     }
 
     public void processMetaPack(String pathToCSV, Boolean exportToZip) throws IOException {
@@ -447,7 +463,7 @@ class SAFPackage {
      * @return Absolute path to the newly created directory
      */
     private String makeNewDirectory(int itemNumber) {
-        File newDirectory = new File(input.getPath() + "/" + outputFilename + "/item_" + itemNumber);
+        File newDirectory = new File(input.getPath() + "/" + outputFilename + "/item_" + String.format(itemNumberFormatString, itemNumber));
         newDirectory.mkdir();
         return newDirectory.getAbsolutePath();
     }


### PR DESCRIPTION
We have at our end the requirement to import items inside a SAF in the same order as they where defined inside the CSV used to create the SAF. 

DSpace sorts the entries inside the SAF alphanumerically while importing the SAF, so an item 11 would be imported after item 9 due to the corresponding item directory names:

   item_1
   item_10
   item_11
   item_2
   item_3
   item_4
   item_5
   item_6
   item_7
   item_8
   item_9

This change uses a String formatter based on the amount of data records to create the SAF item directories, so the sort order fits the order inside the CSV:

  item_01
  item_02
  item_03
  item_04
  item_05
  item_06
  item_07
  item_08
  item_09
  item_10
  item_11
  item_12
